### PR TITLE
Fix for FindSpan

### DIFF
--- a/NINA.Plugin.TargetPlanning/NINA.Plugin.TargetPlanning/Astrometry/Altitudes.cs
+++ b/NINA.Plugin.TargetPlanning/NINA.Plugin.TargetPlanning/Astrometry/Altitudes.cs
@@ -105,7 +105,7 @@ namespace TargetPlanning.NINAPlugin.Astrometry {
 
             // If descending, start from beginning
             if (descending) {
-                for (int i = 0; i < alts.Count; i++) {
+                for (int i = 1; i < alts.Count; i++) {
                     if (alts[i].Altitude < targetAltitude) {
                         List<AltitudeAtTime> span = new List<AltitudeAtTime>(2) {
                             alts[i-1],


### PR DESCRIPTION
FindSpan would fail when the first altitude was less than the target altitude.  Fix by starting the loop at altitude index 1 instead of 0.